### PR TITLE
Compilation fixes

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,13 +7,13 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Android Studio default JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/lib" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The following instructions were tested under Ubuntu 22.04 LTS in a VirtualBox v7
 
 <details>
     <summary>In case of SWIG Syntax Error</summary>
-* Normally the following issue is fixed, but it may creep back up in the future: When building, if you get a `SWIG error: Syntax Error in input(1)` in `includes.h`, this is because there are some lines of code using some syntax that are not accepted in the newest C99 standards, so they need to be modified. The error (and link) given in the Build console in Android Studio will point directly to the problematic functions (because once one is fixed, it will jump to the next one). The issue was fixed by updating to the latest `libqalculate` from v4.4.0 to v4.8.1, which likely implemented syntax fixes.
-    * Don't bother modifying `includes.h` with `#ifndef SWIG .... #endif` blocks as advised [here](https://stackoverflow.com/a/60166645/1121352) because `includes.h` is automatically generated from `libqalculate`, so instead try to fix the root cause by patching or updating to the latest `libqalculate`. The problematic functions were: `EvaluationOptions, SortOptions, PrintOptions, InternalPrintStruct, ParseOptions`
+
+Normally the following issue is fixed, but it may creep back up in the future: When building, if you get a `SWIG error: Syntax Error in input(1)` in `includes.h`, this is because there are some lines of code using some syntax that are not accepted in the newest C99 standards, so they need to be modified. The error (and link) given in the Build console in Android Studio will point directly to the problematic functions (because once one is fixed, it will jump to the next one). The issue was fixed by updating to the latest `libqalculate` from v4.4.0 to v4.8.1, which likely implemented syntax fixes.
+
+Note: Don't bother modifying `includes.h` with `#ifndef SWIG .... #endif` blocks as advised [here](https://stackoverflow.com/a/60166645/1121352) because `includes.h` is automatically generated from `libqalculate`, so instead try to fix the root cause by patching or updating to the latest `libqalculate`. The problematic functions were: `EvaluationOptions, SortOptions, PrintOptions, InternalPrintStruct, ParseOptions`
 </details>
 
 At this point, `libqalculate-android` should build just fine into an `.aar` library file that can be linked into any Android Kotlin project.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# libqalculate-android
+
+Port of libqalculate to Android
+
+## Description
+This is a port of libqalculate using some monkeypatching and SWIG to build it on Android.
+
+It should implement all the features from `libqalculate`, and can easily sync with the latest version by modifying `CMakeLists.txt`.
+
+## Compiling
+The project can only be built under Linux (maybe MacOS too) but not on Windows as it relies on bash shell scripts. On Windows, you can use a virtual machine.
+
+The following instructions were tested under Ubuntu 22.04 LTS in a VirtualBox v7 virtualized environment, using Android Studio 2022.3.1:
+
+* Install Android Studio. Once it is installed, go into the SDK Manager, and install `NDK` in the Build Tools tab.
+* `git clone` this repository: `git clone https://github.com/jherkenhoff/libqalculate-android`
+* Install all the required toolchain libraries for compilation: `sudo apt-get install cmake swig m4 ninja-build g++ intltool`
+    * Ensure CMake >= 3.22.1. If it is different from 3.22.1, then [specify the version you have installed in build.gradle](https://stackoverflow.com/questions/60718412/could-not-get-version-from-cmake-dir), so that `cmake` path can be found when compiling.
+    * Troubleshooting: 
+        * if you don't apt-get install m4, you will get [this error](https://stackoverflow.com/questions/11368989/no-usable-m4-in-path-or-usr5bin)!
+        * if `/bin/ninja` is not present then you will get [this weird error](https://github.com/expo/expo/issues/22029) that is due to [ninja being in a different folder than cmake](https://issuetracker.google.com/issues/206099937), so ensure to apt-get install ninja-build.
+        * if no g++, you get [this error](https://askubuntu.com/questions/509663/c-preprocessor-lib-cpp-fails-sanity-check).
+
+<details>
+    <summary>In case of SWIG Syntax Error</summary>
+* Normally the following issue is fixed, but it may creep back up in the future: When building, if you get a `SWIG error: Syntax Error in input(1)` in `includes.h`, this is because there are some lines of code using some syntax that are not accepted in the newest C99 standards, so they need to be modified. The error (and link) given in the Build console in Android Studio will point directly to the problematic functions (because once one is fixed, it will jump to the next one). The issue was fixed by updating to the latest `libqalculate` from v4.4.0 to v4.8.1, which likely implemented syntax fixes.
+    * Don't bother modifying `includes.h` with `#ifndef SWIG .... #endif` blocks as advised [here](https://stackoverflow.com/a/60166645/1121352) because `includes.h` is automatically generated from `libqalculate`, so instead try to fix the root cause by patching or updating to the latest `libqalculate`. The problematic functions were: `EvaluationOptions, SortOptions, PrintOptions, InternalPrintStruct, ParseOptions`
+</details>
+
+At this point, `libqalculate-android` should build just fine into an `.aar` library file that can be linked into any Android Kotlin project.
+
+To get the app, you need to compile [qalculate-android](https://github.com/jherkenhoff/qalculate-android), just `git clone` it in a folder alongside `libqalculate-android` (both folders must be siblings), then try to build from `qalculate-android` using `./gradlew assembleDebug` or via Android Studio to get an `.apk` file. If any issue is encountered, Build > Rebuild Project (maybe after project clean in the same menu).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(libgmp PROPERTIES
 
 
 ExternalProject_Add(mpfr
-        URL https://www.mpfr.org/mpfr-current/mpfr-4.1.1.tar.xz
+        URL https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.1.tar.xz
         URL_HASH MD5=d182b62e811f744d149b14540d8e922b
         CONFIGURE_COMMAND ${CROSS_COMPILE_PREFIX} <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host ${ANDROID_LLVM_TRIPLE} --with-gmp=${GMP_INSTALL_DIR}
         BUILD_COMMAND make
@@ -156,8 +156,8 @@ set(QALCULATE_LIBXML_CFLAGS "-I${XML2_INSTALL_DIR}/include/libxml2")
 set(QALCULATE_LIBXML_LIBS "-L${XML2_INSTALL_DIR}/lib -lxml2")
 
 ExternalProject_Add(qalculate
-        URL https://github.com/Qalculate/libqalculate/releases/download/v4.4.0/libqalculate-4.4.0.tar.gz
-        URL_HASH MD5=d30ad11c8920c2ec929745d42bd2854e
+        URL https://github.com/Qalculate/libqalculate/releases/download/v4.8.1/libqalculate-4.8.1.tar.gz
+        URL_HASH MD5=163D341990A5D52222E8E4F5F65E2D5D
         PATCH_COMMAND patch <SOURCE_DIR>/libqalculate/util.cc < ${CMAKE_CURRENT_LIST_DIR}/src/main/cpp/liqalculate_util.patch
         CONFIGURE_COMMAND ${CROSS_COMPILE_PREFIX} <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host ${ANDROID_LLVM_TRIPLE} --without-icu --without-libcurl --without-libintl-prefix --enable-compiled-definitions CPPFLAGS=${QALCULATE_CPPFLAGS} LDFLAGS=${QALCULATE_LDFLAGS} LIBXML_CFLAGS=${QALCULATE_LIBXML_CFLAGS} LIBXML_LIBS=${QALCULATE_LIBXML_LIBS}
         BUILD_COMMAND make

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -40,7 +40,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
-            version '3.10.2'
+            version '3.22.1'  // EDITME: update with the version of CMake you have installed on your system - must be above cmake_minimum_required specified in CMakeLists.txt
         }
     }
     buildFeatures {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -40,7 +40,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
-            version '3.22.1'  // EDITME: update with the version of CMake you have installed on your system - must be above cmake_minimum_required specified in CMakeLists.txt
+            version '3.10.2'
         }
     }
     buildFeatures {


### PR DESCRIPTION
This release ensure compilation works with the latest stable releases of the toolchain, and updates the compiling instructions in the readme.

More specifically:
* bump libqalculate to v4.8.1 (fixes syntax errors in SWIG compilation)
* bump CMake 3.22.1
* fix mpfr link (old is down, new is gnu servers so unlikely to ever go down)
* add content in README (including detailed compilation instructions)

Since the build was done in a fresh virtual environment as described in the readme, it should be reproducible by anyone.